### PR TITLE
タグページの用意

### DIFF
--- a/layouts/entry.html
+++ b/layouts/entry.html
@@ -3,14 +3,18 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <meta name="description" content="<?= $vars->{description} ?>">
-        <meta name="author" content="<?= $vars->{author} ?>">
+        <meta name="description" content="<?= $vars->{matter}->description ?>">
+        <meta name="author" content="<?= $vars->{matter}->author ?>">
         <title><?= $vars->{subtitle} ? "$vars->{title} - $vars->{subtitle}" : $vars->{title} ?></title>
         <link rel="icon" href="/img/favicon.ico">
         <link href="TODO" rel="stylesheet">
     </head>
     <body>
         <h1><?= $vars->{title} ?></h1>
+        tag
+?       for my $tag ($vars->{matter}->tags->@*) {
+            <a href='<?= "/tag/$tag" ?>'><?= $tag ?></a>
+?       }
 
         <?= $vars->{text} ?>
         <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js?lang=css&amp;skin=sunburst"></script>

--- a/layouts/tag.html
+++ b/layouts/tag.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="ja">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <meta name="description" content="<?= $vars->{description} ?>">
+        <title><?= $vars->{title} ?></title>
+        <link rel="icon" href="/img/favicon.ico">
+        <link href="TODO" rel="stylesheet">
+    </head>
+    <body>
+        <h1><?= $vars->{tag} ?></h1>
+        <ul>
+?           for (@{$vars->{files}}) {
+            <li>
+                <a href="<?= $_->{href} ?>">
+                    <?= $_->{title} ?>
+                </a>
+            </li>
+?           }
+        </ul>
+
+        <a href="/tag">タグ一覧</a>
+        <a href="/">HOME</a>
+
+    </body>
+</html>

--- a/layouts/tag_index.html
+++ b/layouts/tag_index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="ja">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <meta name="description" content="cription} ?>">
+        <title>タグ一覧</title>
+        <link rel="icon" href="/img/favicon.ico">
+        <link href="TODO" rel="stylesheet">
+    </head>
+    <body>
+        <h1>タグ一覧</h1>
+        <ul>
+?           for my $tag (@{$vars->{tags}}) {
+            <li>
+                <a href=<?= "/tag/$tag" ?>>
+                    <?= $tag ?>
+                </a>
+            </li>
+?           }
+        </ul>
+
+        <a href="/">HOME</a>
+
+    </body>
+</html>

--- a/lib/PerlUsersJP/Builder.pm
+++ b/lib/PerlUsersJP/Builder.pm
@@ -315,7 +315,7 @@ sub build_atom {
 
 sub diag {
     my ($self, $msg) = @_;
-    #print $msg;
+    print $msg;
 }
 
 sub to_public {

--- a/lib/PerlUsersJP/Builder.pm
+++ b/lib/PerlUsersJP/Builder.pm
@@ -72,9 +72,8 @@ sub build_entries {
         $self->build_entry($src);
     }
 
-    $self->build_categories($src_list);
-    # TODO
-    #$self->build_tags(\@entries);
+    #$self->build_categories($src_list);
+    $self->build_tags($src_list);
     #$self->build_sitemap(\@entries);
     #$self->build_atom(\@entries);
 }
@@ -233,8 +232,75 @@ sub category_description {
 }
 
 sub build_tags {
-    my ($self, $entries) = @_;
-    ... # TODO
+    my ($self, $src_list) = @_;
+
+    my %tag_map;
+    for my $src ($src_list->@*) {
+        my $matter = $self->front_matter($src);
+        next unless $matter->exists;
+
+        for my $tag ($matter->tags->@*) {
+            push $tag_map{$tag}->@*, $src;
+        }
+    }
+
+    $self->build_tag_index([keys %tag_map]);
+
+    for my $tag (keys %tag_map) {
+        my $src_list = $tag_map{$tag};
+        $self->build_tag($tag, $src_list);
+    }
+}
+
+sub build_tag_index {
+    my ($self, $tags) = @_;
+
+    my $html = $self->_render_string('tag_index.html', {
+        tags => [sort { $a cmp $b } $tags->@*],
+    });
+
+    my $tag_dir = $self->public_dir->child('tag');
+    my $dest = $tag_dir->child('index.html');
+    $tag_dir->mkpath unless $tag_dir->is_dir;
+    $dest->spew_utf8($html);
+    $self->diag("Created tag_list $dest\n");
+}
+
+sub build_tag {
+    my ($self, $tag, $src_list) = @_;
+
+    my @src_list = map {
+        my $file   = Path::Tiny::path($_);
+        my $matter = $self->front_matter($file);
+        my $title  = $matter->title;
+
+        # content/foo/bar.txt => /foo/bar
+        my $href = do {
+            my $content_dir = $self->content_dir;
+            my $path = $file =~ s!$content_dir!!r;
+            my $href = $path =~ s!\.([^.]+)$!!r;
+            $href;
+        };
+        {
+            file   => $file,
+            matter => $matter,
+            title  => $title,
+            href   => $href,
+        }
+    } $src_list->@*;
+
+    my $html = $self->_render_string('tag.html', {
+        tag         => $tag,
+        description => $tag,
+        title       => $tag,
+        files       => [ sort { $a->{title} cmp $b->{title} } @src_list ],
+    });
+
+    my $tag_dir = $self->public_dir->child('tag', $tag);
+    my $dest = $tag_dir->child('index.html');
+    $tag_dir->mkpath unless $tag_dir->is_dir;
+    $dest->spew_utf8($html);
+    $self->diag("Created tag $dest\n");
 }
 
 sub build_sitemap {
@@ -249,7 +315,7 @@ sub build_atom {
 
 sub diag {
     my ($self, $msg) = @_;
-    print $msg;
+    #print $msg;
 }
 
 sub to_public {

--- a/lib/PerlUsersJP/Builder.pm
+++ b/lib/PerlUsersJP/Builder.pm
@@ -72,7 +72,7 @@ sub build_entries {
         $self->build_entry($src);
     }
 
-    #$self->build_categories($src_list);
+    $self->build_categories($src_list);
     $self->build_tags($src_list);
     #$self->build_sitemap(\@entries);
     #$self->build_atom(\@entries);
@@ -161,7 +161,8 @@ sub build_categories {
     my ($self, $src_list) = @_;
 
     my %src_list_map;
-    for my $src ($src_list->@*) {
+    for ($src_list->@*) {
+        my $src      = $_;
         my $category = $src->parent;
         while ($category ne $self->content_dir) {
             $src_list_map{$category}{$src} = 1;

--- a/lib/PerlUsersJP/Builder.pm
+++ b/lib/PerlUsersJP/Builder.pm
@@ -117,8 +117,7 @@ sub build_entry {
             text        => $self->entry_text($src),
             title       => $matter->title,
             subtitle    => $self->entry_subtitle($src),
-            author      => $matter->author,
-            description => $matter->description,
+            matter      => $matter,
         });
         $dest->spew_utf8($html);
         $sub_dest->spew_utf8($html) if $sub_dest;

--- a/lib/PerlUsersJP/FrontMatter.pm
+++ b/lib/PerlUsersJP/FrontMatter.pm
@@ -35,11 +35,12 @@ sub BUILDARGS {
         return {
             format => $format,
             title  => $data->{title} // '',
+            tags   => [], # TODO HTMLでもタグ対応したいね
         }
     }
     else {
         my $data    = _parse_text_entry($file);
-        my $tags    = $data->{tags} ? [split ',', $data->{tags}] : [];
+        my $tags    = $data->{tags} ? [ grep { $_ } map { s!\s*!!; s!\s*$!!; $_ } split /[,\s]/, $data->{tags} ] : [];
 
         return {
             body        => $data->{body},


### PR DESCRIPTION
次の３つを見れるようにした。

1. エントリーからタグが見ることができ、そこからタグに関連するエントリー一覧を見れるようにする
この例では、「perl hacker iphone anyevent」を指定
![image](https://user-images.githubusercontent.com/722500/73274777-7c9d5700-4229-11ea-81d3-63cafad072fd.png)

2. タグに関連するエントリー一覧を見れるようにする。この例では、「hacker」というタグに関連するエントリー一覧。URL pathは、 `/tag/:tag`
![image](https://user-images.githubusercontent.com/722500/73274804-87f08280-4229-11ea-8625-7e4c1dc26c1a.png)

3. タグの一覧。URL pathは、`/tag/`
![image](https://user-images.githubusercontent.com/722500/73274819-8e7efa00-4229-11ea-89ef-4544765f653a.png)

