### PR TITLE
はてな記法の脚注を微修正

### DIFF
--- a/lib/PerlUsersJP/Builder.pm
+++ b/lib/PerlUsersJP/Builder.pm
@@ -359,7 +359,7 @@ sub format_text {
             $html .= "\n<div class=\"footnotes\">\n";
             $html .= join "\n", map {
                 sprintf(
-                    '  <div class="footnote" id="#fn%d">*%d: %s</div>',
+                    '  <div class="footnote" id="fn%d">*%d: %s</div>',
                     $_->{number}, $_->{number}, $_->{note},
                 )
             } @{ $inline->footnotes };


### PR DESCRIPTION
#10 で対応できていると思ったんですが、(cho45さんの記事につられて) 間違えていました。idに `#` も含んでいるとクリックした時にスクロールしませんでした。確認が足りなくて、すみません。