### PR TITLE
Substitute Foo::Bar to Foo-Bar

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,8 @@
 requires 'perl', '5.030001';
 
+requires 'Encode::Locale';
+requires 'Encode';
+
 requires 'Class::Tiny';
 requires 'Date::Format';
 requires 'Path::Tiny';

--- a/layouts/tag_index.html
+++ b/layouts/tag_index.html
@@ -13,7 +13,7 @@
         <ul>
 ?           for my $tag (@{$vars->{tags}}) {
             <li>
-                <a href=<?= "/tag/$tag" ?>>
+                <a href=<?= normalize_name "/tag/$tag" ?>>
                     <?= $tag ?>
                 </a>
             </li>

--- a/lib/PerlUsersJP/Builder.pm
+++ b/lib/PerlUsersJP/Builder.pm
@@ -7,7 +7,7 @@ use feature qw(state);
 use PerlUsersJP::FrontMatter;
 
 use Encode::Locale;
-use Encode qw(decode encode);
+use Encode qw(encode);
 
 use Path::Tiny ();
 use Date::Format ();

--- a/lib/PerlUsersJP/Builder.pm
+++ b/lib/PerlUsersJP/Builder.pm
@@ -6,6 +6,9 @@ use feature qw(state);
 
 use PerlUsersJP::FrontMatter;
 
+use Encode::Locale;
+use Encode qw(decode encode);
+
 use Path::Tiny ();
 use Date::Format ();
 use Scalar::Util ();
@@ -176,6 +179,11 @@ sub build_categories {
     }
 }
 
+sub normalize_name {
+    my ($name) = @_;
+    return $name =~ s!::!-!gr;
+}
+
 sub build_category {
     my ($self, $src_category, $src_list) = @_;
 
@@ -296,7 +304,7 @@ sub build_tag {
         files       => [ sort { $a->{title} cmp $b->{title} } @src_list ],
     });
 
-    my $tag_dir = $self->public_dir->child('tag', $tag);
+    my $tag_dir = $self->public_dir->child('tag', encode(locale => normalize_name($tag)));
     my $dest = $tag_dir->child('index.html');
     $tag_dir->mkpath unless $tag_dir->is_dir;
     $dest->spew_utf8($html);


### PR DESCRIPTION
ファイルシステム上は `Foo::Bar` じゃなく `Foo-Bar` の方がいいと思いました。

あと Encode::Locale 使って ~Windows~ 某 OS でも動く様にしました。現状パスに日本語が現れるのがタグだけだったのでそこしか対応してません。