### PR TITLE
プレビューが作成されるタイミングから push を削除

### DIFF
--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -1,6 +1,5 @@
 name: Build and Deploy to Netlify
 on:
-  push:
   pull_request:
     types: [opened, synchronize]
 jobs:


### PR DESCRIPTION
プルリクの作成時と更新時のみでプレビューが作成されるように変更しました

これまではプルリクのない状態の push 時にも作成されていました。しかし、この状態ではコメントが二重に作成されてしまうことと、プレビュー作成はプルリクができるまで待っても問題がないという判断から、削除しました。